### PR TITLE
Race condition in concurrent shutdown/startup (2: locking)

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -361,10 +361,16 @@ module Resque
         false
       rescue Interrupt
         if @shutdown
-          Resque.clean_schedules
-          release_master_lock
+          before_shutdown
         end
         true
+      end
+
+      def before_shutdown
+        Resque.with_startup_watch do
+          Resque.clean_schedules
+        end
+        release_master_lock
       end
 
       # Sets the shutdown flag, clean schedules and exits if sleeping

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'mocha'
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'rack-test'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'simplecov'

--- a/test/multi_process_test.rb
+++ b/test/multi_process_test.rb
@@ -5,7 +5,7 @@ context 'Multi Process' do
   test 'setting schedule= from many process does not corrupt the schedules' do
     schedules = {}
     counts  = []
-    threads = []
+    pids = []
 
     # This number may need to be increased if this test is not failing
     processes = 20
@@ -17,10 +17,10 @@ context 'Multi Process' do
     end
 
     processes.times do |n|
-      threads << Thread.new do
-        sleep n * 0.1
+      pids << fork_with_marshalled_pipe_and_result do
+        sleep 1.0/(n+1) * 0.2
         Resque.schedule = schedules
-        counts << Resque.schedule.size
+        Resque.schedule.size
       end
     end
 
@@ -28,10 +28,91 @@ context 'Multi Process' do
     Resque.schedule = schedules
     counts << Resque.schedule.size
 
-    threads.each(&:join)
+    counts += get_results_from_children(pids)
 
     counts.each_with_index do |c, i|
       assert_equal schedule_count, c, "schedule count is incorrect (c: #{i})"
     end
+  end
+
+  test 'schedule doesnt corrupt when a few processes start/stop concurrently' do
+    counts  = []
+    children = []
+    redis = Resque.redis
+
+    processes = 80
+
+    schedules = {}
+    schedule_count = 300
+    schedule_count.times do |n|
+      schedules["job_#{n}"] = { "cron" => '0 1 0 0 0' }
+    end
+
+    Resque.schedule = schedules
+
+    processes.times do |n|
+      children << fork_with_marshalled_pipe_and_result do
+        time = Random.rand(3) * 1
+        sleep time
+        if n % 2 == 0
+          Resque.schedule = schedules
+          Resque.schedule.size
+        else
+          Resque::Scheduler.before_shutdown
+          nil
+        end
+      end
+    end
+
+    counts += get_results_from_children(children).compact
+
+    counts.each_with_index do |c, i|
+      assert_equal schedule_count, c, "schedule count is incorrect (c: #{i})\n counts: #{counts}"
+    end
+  end
+
+  private
+
+  def fork_with_marshalled_pipe_and_result
+    pipe_read, pipe_write = IO.pipe
+    pid = fork do
+      pipe_read.close
+      result = begin
+        [yield, nil]
+      rescue Exception => exc
+        [nil, exc]
+      end
+      pipe_write.syswrite(Marshal.dump(result))
+      # exit true the process to get around fork issues on minitest 5
+      # see https://github.com/seattlerb/minitest/issues/467
+      Process.exit!(true)
+    end
+    pipe_write.close
+
+    [pid, pipe_read]
+  end
+
+  def get_results_from_children(children)
+    results = []
+    children.each do |pid, pipe|
+      wait_for_child_process_to_terminate(pid)
+
+      raise "forked process failed with #{$?.to_s}" unless $?.success?
+      result, exc = Marshal.load(pipe.read)
+      raise exc if exc
+      results << result
+    end
+    results
+  end
+
+  def wait_for_child_process_to_terminate(pid = -1, timeout: 30)
+    Timeout.timeout(timeout) do
+      Process.wait(pid)
+    end
+  rescue Timeout::Error
+    Process.kill('KILL', pid)
+    # collect status so it doesn't stick around as zombie process
+    Process.wait(pid)
+    flunk "Child process did not terminate in time."
   end
 end


### PR DESCRIPTION
This is a scrappy version of the locking method. It forces instances to set their schedules one by one
@fw42 