### PR TITLE
Refactor delayed jobs backend

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -175,37 +175,20 @@ module Resque
       # Handles queueing delayed items
       # at_time - Time to start scheduling items (default: now).
       def handle_delayed_items(at_time = nil)
-        timestamp = Resque.next_delayed_timestamp(at_time)
-        if timestamp
-          procline 'Processing Delayed Items'
-          until timestamp.nil?
-            enqueue_delayed_items_for_timestamp(timestamp)
-            timestamp = Resque.next_delayed_timestamp(at_time)
-          end
-        end
-      end
-
-      def enqueue_next_item(timestamp)
-        item = Resque.next_item_for_timestamp(timestamp)
-
-        if item
-          log "queuing #{item['class']} [delayed]"
-          enqueue(item)
-        end
-
-        item
-      end
-
-      # Enqueues all delayed jobs for a timestamp
-      def enqueue_delayed_items_for_timestamp(timestamp)
+        at_time ||= Time.now
+        procline 'Processing Delayed Items'
         item = nil
+
         loop do
           handle_shutdown do
-            # Continually check that it is still the master
-            item = enqueue_next_item(timestamp) if master?
+            if master?
+              item = Resque.next_delayed_item(before: at_time)
+
+              log "queuing #{item['class']} [delayed]"
+              enqueue(item) if item
+            end
           end
-          # continue processing until there are no more ready items in this
-          # timestamp
+
           break if item.nil?
         end
       end

--- a/lib/resque/scheduler/delaying_extensions.rb
+++ b/lib/resque/scheduler/delaying_extensions.rb
@@ -62,85 +62,67 @@ module Resque
       # if O(log(n)).  Returns true if it's the first job to be scheduled at
       # that time, else false
       def delayed_push(timestamp, item)
-        # First add this item to the list for this timestamp
-        redis.rpush("delayed:#{timestamp.to_i}", encode(item))
-
         # Store the timestamps at with this item occurs
         redis.sadd("timestamps:#{encode(item)}", "delayed:#{timestamp.to_i}")
 
-        # Now, add this timestamp to the zsets.  The score and the value are
-        # the same since we'll be querying by timestamp, and we don't have
-        # anything else to store.
-        redis.zadd :delayed_queue_schedule, timestamp.to_i, timestamp.to_i
+        redis.zadd(:delayed_queue, timestamp.to_i, encode_with_nonce(item))
       end
 
       # Returns an array of timestamps based on start and count
       def delayed_queue_peek(start, count)
-        result = redis.zrange(:delayed_queue_schedule, start,
-                              start + count - 1)
-        Array(result).map(&:to_i)
+        result = redis.zrange(:delayed_queue, start, count, withscores: true)
+        result.map(&:last).map(&:to_i)
       end
 
       # Returns the size of the delayed queue schedule
       def delayed_queue_schedule_size
-        redis.zcard :delayed_queue_schedule
+        redis.zcard :delayed_queue
       end
 
       # Returns the number of jobs for a given timestamp in the delayed queue
       # schedule
       def delayed_timestamp_size(timestamp)
-        redis.llen("delayed:#{timestamp.to_i}").to_i
+        redis.zcount(:delayed_queue, timestamp.to_i, timestamp.to_i)
       end
 
       # Returns an array of delayed items for the given timestamp
-      def delayed_timestamp_peek(timestamp, start, count)
-        if 1 == count
-          r = list_range "delayed:#{timestamp.to_i}", start, count
-          r.nil? ? [] : [r]
-        else
-          list_range "delayed:#{timestamp.to_i}", start, count
+      def delayed_timestamp_peek(timestamp, offset, count)
+        resp = redis.zrangebyscore :delayed_queue, timestamp.to_i, timestamp.to_i, limit: [offset, count]
+        resp.map {|job| decode_without_nonce(job) }
+      end
+
+      def next_delayed_item(before:)
+        item, time = redis.zrangebyscore(:delayed_queue, 0.0, before.to_i, limit: [0, 1], with_scores: true).first
+
+        if item
+          decoded = decode_without_nonce(item)
+
+          redis.zrem(:delayed_queue, item)
+          redis.srem("timestamps:#{encode(decoded)}", "delayed:#{time.to_i}")
+
+          decoded
         end
-      end
-
-      # Returns the next delayed queue timestamp
-      # (don't call directly)
-      def next_delayed_timestamp(at_time = nil)
-        search_first_delayed_timestamp_in_range(nil, at_time || Time.now)
-      end
-
-      # Returns the next item to be processed for a given timestamp, nil if
-      # done. (don't call directly)
-      # +timestamp+ can either be in seconds or a datetime
-      def next_item_for_timestamp(timestamp)
-        key = "delayed:#{timestamp.to_i}"
-
-        encoded_item = redis.lpop(key)
-        redis.srem("timestamps:#{encoded_item}", key)
-        item = decode(encoded_item)
-
-        # If the list is empty, remove it.
-        clean_up_timestamp(key, timestamp)
-        item
       end
 
       # Clears all jobs created with enqueue_at or enqueue_in
       def reset_delayed_queue
-        Array(redis.zrange(:delayed_queue_schedule, 0, -1)).each do |item|
-          key = "delayed:#{item}"
-          items = redis.lrange(key, 0, -1)
-          redis.pipelined do
-            items.each { |ts_item| redis.del("timestamps:#{ts_item}") }
-          end
-          redis.del key
+        redis.zrange(:delayed_queue, 0, -1).each do |job|
+          timestamp_key = encode(decode_without_nonce(job))
+          redis.del("timestamps:#{timestamp_key}")
         end
 
-        redis.del :delayed_queue_schedule
+        redis.del :delayed_queue
       end
 
       # Given an encoded item, remove it from the delayed_queue
       def remove_delayed(klass, *args)
         search = encode(job_to_hash(klass, args))
-        remove_delayed_job(search)
+        timestamps = redis.smembers("timestamps:#{search}")
+
+        timestamps.map do |timestamp_key|
+          timestamp = timestamp_key.split(":").last.to_i
+          remove_delayed_job_from_timestamp(timestamp, klass, *args)
+        end.reduce(:+) || 0
       end
 
       # Given an encoded item, enqueue it now
@@ -186,22 +168,14 @@ module Resque
       def find_delayed_selection(klass = nil, &block)
         raise ArgumentError, 'Please supply a block' unless block_given?
 
-        timestamps = redis.zrange(:delayed_queue_schedule, 0, -1)
+        found = []
 
-        # Beyond 100 there's almost no improvement in speed
-        found = timestamps.each_slice(100).map do |ts_group|
-          jobs = redis.pipelined do |r|
-            ts_group.each do |ts|
-              r.lrange("delayed:#{ts}", 0, -1)
-            end
-          end
-
-          jobs.flatten.select do |payload|
-            payload_matches_selection?(decode(payload), klass, &block)
+        redis.zscan_each(:delayed_queue) do |payload, _|
+          if payload_matches_selection?(decode(payload), klass, &block)
+            found << payload
           end
         end
-
-        found.flatten
+        found
       end
 
       # Given a timestamp and job (klass + args) it removes all instances and
@@ -212,22 +186,21 @@ module Resque
       def remove_delayed_job_from_timestamp(timestamp, klass, *args)
         return 0 if Resque.inline?
 
-        key = "delayed:#{timestamp.to_i}"
-        encoded_job = encode(job_to_hash(klass, args))
+        job_hash = job_to_hash(klass, args)
 
-        redis.srem("timestamps:#{encoded_job}", key)
-        count = redis.lrem(key, 0, encoded_job)
-        clean_up_timestamp(key, timestamp)
+        redis.srem("timestamps:#{encode(job_hash)}", "delayed:#{timestamp.to_i}")
 
-        count
+        ret = redis.zrangebyscore(:delayed_queue, timestamp.to_i, timestamp.to_i, with_scores: true).map do |job, time|
+          next unless time == timestamp.to_i
+
+          redis.zrem(:delayed_queue, job) if encode(decode_without_nonce(job)) == encode(job_hash)
+        end
+
+        ret.count(true)
       end
 
       def count_all_scheduled_jobs
-        total_jobs = 0
-        Array(redis.zrange(:delayed_queue_schedule, 0, -1)).each do |ts|
-          total_jobs += redis.llen("delayed:#{ts}").to_i
-        end
-        total_jobs
+        redis.zcard(:delayed_queue)
       end
 
       # Discover if a job has been delayed.
@@ -243,7 +216,7 @@ module Resque
       def scheduled_at(klass, *args)
         search = encode(job_to_hash(klass, args))
         redis.smembers("timestamps:#{search}").map do |key|
-          key.tr('delayed:', '').to_i
+          key.split(":").last.to_i
         end
       end
 
@@ -257,12 +230,20 @@ module Resque
 
       private
 
+      def decode_without_nonce(job)
+        decode(job)&.delete_if {|k, _| k == 'nonce'}
+      end
+
       def job_to_hash(klass, args)
-        { class: klass.to_s, args: args, queue: queue_from_class(klass) }
+        job_to_hash_with_queue(queue_from_class(klass), klass, args)
       end
 
       def job_to_hash_with_queue(queue, klass, args)
         { class: klass.to_s, args: args, queue: queue }
+      end
+
+      def encode_with_nonce(hash)
+        encode(hash.merge(nonce: rand))
       end
 
       def remove_delayed_job(encoded_job)
@@ -271,42 +252,14 @@ module Resque
         timestamps = redis.smembers("timestamps:#{encoded_job}")
 
         replies = redis.pipelined do
+          redis.zrem(:delayed_queue, [encoded_job])
           timestamps.each do |key|
-            redis.lrem(key, 0, encoded_job)
             redis.srem("timestamps:#{encoded_job}", key)
           end
         end
 
         return 0 if replies.nil? || replies.empty?
-        replies.each_slice(2).map(&:first).inject(:+)
-      end
-
-      def clean_up_timestamp(key, timestamp)
-        # Use a watch here to ensure nobody adds jobs to this delayed
-        # queue while we're removing it.
-        redis.watch(key) do
-          if redis.llen(key).to_i == 0
-            # If the list is empty, remove it.
-            redis.multi do
-              redis.del(key)
-              redis.zrem(:delayed_queue_schedule, timestamp.to_i)
-            end
-          else
-            redis.redis.unwatch
-          end
-        end
-      end
-
-      def search_first_delayed_timestamp_in_range(start_at, stop_at)
-        start_at = start_at.nil? ? '-inf' : start_at.to_i
-        stop_at = stop_at.nil? ? '+inf' : stop_at.to_i
-
-        items = redis.zrangebyscore(
-          :delayed_queue_schedule, start_at, stop_at,
-          limit: [0, 1]
-        )
-        timestamp = items.nil? ? nil : Array(items).first
-        timestamp.to_i unless timestamp.nil?
+        replies.first
       end
 
       def payload_matches_selection?(decoded_payload, klass)


### PR DESCRIPTION
## Refactoring the delayed job backend

Resque Scheduler provides two modes of function for us: cron jobs and delayed jobs. Each of those is implemented separately in the codebase. For our purposes we are interested by the API exposed in `delaying_extensions.rb` and it's implications. 

Delayed jobs are jobs in shopify enqueued with the `wait:` or the `wait_until:` paramters. These jobs are expected to run at specific timestamps ideally down to the second (not strictly necessary for our purposes of course). Resque Scheduler maintains a set of datastructures to enable that functionality each delayed job involves modifying 3 separate keys: 

1. `delayed_queue_schedule`: A ZSET tracking the timestamps of jobs in the queue. 
2. `delayed:#{timestamp}`: A List of jobs for a specific timestamp
3. `timestamp:#{job_hash}`: A List of queues where a specific job can be found. Used for Dashboard

Enqueuing a job will require pushing values into all three of the associated queues for a job. Dequeuing a job requires reading the next timestamp from the `delayed_queue_schedule` and then reading jobs out of that queue. 

So, what's the issue with this architecture? It's not a good fit for shopify! To start, we rarely have jobs enqueued for the same second, meaning that effectively every queue has length 1! Additionally, since the _full_ job hash is used as the timestamp key our job_id parameter ensures that _every_ job has it's own singleton `timestamp:#{job_hash}` queue! On top of this, we have a _lot_ of delayed jobs, the average resque server has 30,000 delayed jobs. This basically means that we are the worst case scenario for redis lists!

### Why does this matter now?

Recently, `transfer_jobs` was rewritten to take advantage of batching, by fetching multiple jobs (1000) from queues in a single go. However, since delayed jobs end up in singleton lists, that defeats all of our batching and forces us to perform 1000 times more redis commands than what should be necessary. This translates to job transfers taking up to 1h30m for production pods! As moves become more frequent, automated and unsupervised this can't be allowed to continue. 

### So we need to do something but why this?

Multiple options were considered before opting for a rewrite of the backend. 

First, the #redis-memcached team is isolating every redis so we will have less queues to traverse, since we'll only have 1 pod of delayed jobs instead of ~4. Even with a reduciont of 4x the number of queues that will still result in 7-8k delayed queues to transfer and with linear time reduction will take 22m30s. That's a huge win and will be finished by BFCM but _isnt enough_!

Then we also considered bucketing delayed jobs, instead of enqueuing them to the second or millisecond, enqueue them in buckets of 5 or 10 seconds! This could even be controlled on the Shopify Core side avoiding _any_ changes to resque-scheduler. However, this leaks a ton of abstraction to the user since we have a lot of tests asserting run times / delays for tests. It also makes our jobs 'spiky' if we have hundreds of thousands of delayed jobs (due to errors) instead of having them spread out we get them in 5-10x larger increments.

Finally, we also considered writing lua scripts to support fetching multiple queues from redis at a time. We rejected this because transfer_jobs is already fairly complex and adding lua scripts will only increase that complexity. Lua scripts also cause multiple issues because we can't easily control the batch size. If we fetch 1000 queues those could all be singletons or some of them could have _thousands_ of jobs in them. Additionally, we'd have to rewrite transfer jobs again to support batching in that manner. 

That leaves us with our current approach: rewrite delayed jobs to use a single queue. This is the architecture used by Sidekiq to store it's delayde jobs as well!

### Benefits of this approach

Besides the increased transfer jobs performance we should get some other minor benefits from this approach. 

1. Queue size tracking: currently spy doesnt report delayed jobs at all since it would take upwards of 30k redis calls (llen foreach queue). With this setup we only need to do a single `zcard`. 
2. Safer dequeues: Currently if resque-schduler crashes while processing a delayed queue, it will lose the timestamp of that queue since it performs a `zrem` to fetch it. 

### The implementation

The actual rewrite diff is approximately 200 lines with very minor adjustments to some tests. It was mainly a matter of removing the `delayed:timestamp` queues and just putting them into the `delayed_queue` zset. However, there were a few adjustments that had to be made to ensure compatibility with current resque-scheduler. Zsets ar well, sets which means we can't have duplicate values inserted into them. Since resque doesn't mandate unique job ids we can't rely on jobs actually having unique values! To get around this we instead insert a random nonce into every job hash before encoding the json. This ensures that every job will effectively be unique. With this fix the rest of the solution more or less fell into place on it's own

## Migration

After discusison, @es and I realized the only real choice for migration is to support an online migration where we allow resque scheduler to read both formats and prefer the newer format. To achieve this we keep around a version of the old code in `DelayingExtensionsOld` and monkey patch `Resque::Scheduler` to enqueue jobs from both the old and new versions of the code. However, clients won't see the `Resque::Scheduler::DelayingExtensionsOld` and therefore will push onto the new queue. 

The migration can be considered finished once there is no `delayed_queue_schedule` key left in redis. 

@es will provide a test suite ensuring that migration is safe, reading old and new jobs in the correct order while ensuring no jobs are dropped from either queue. 