### PR TITLE
Remove all timestamps related code

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ RuboCop::RakeTask.new
 Rake::TestTask.new(:testing) do |t|
   t.libs << 'test'
   t.pattern = ENV['PATTERN'] || 'test/*_test.rb'
+  t.warning = false
   t.options = ''.tap do |o|
     o << "--seed #{ENV['SEED']} " if ENV['SEED']
     o << '--verbose ' if ENV['VERBOSE']

--- a/lib/resque/scheduler/locking.rb
+++ b/lib/resque/scheduler/locking.rb
@@ -97,7 +97,7 @@ module Resque
       end
 
       def redis_master_version
-        Resque.redis.info['redis_version'].to_f
+        Resque.redis.redis.info['redis_version'].to_f
       end
     end
   end

--- a/lib/resque/scheduler_migrator.rb
+++ b/lib/resque/scheduler_migrator.rb
@@ -28,7 +28,7 @@ module Resque
 
       if item
         Resque::Scheduler.log "migrating #{item['class']} [delayed] from old format to new format"
-        Resque.delayed_push(timestamp, item)
+        Resque.send(:delayed_push, timestamp, item)
       end
 
       item

--- a/test/scheduler_hooks_test.rb
+++ b/test/scheduler_hooks_test.rb
@@ -9,7 +9,7 @@ context 'scheduling jobs with hooks' do
     SomeRealClass.expects(:before_schedule_example).with(:foo)
     SomeRealClass.expects(:after_schedule_example).with(:foo)
     Resque.enqueue_at(enqueue_time.to_i, SomeRealClass, :foo)
-    assert_equal(1, Resque.delayed_timestamp_size(enqueue_time.to_i),
+    assert_equal(1, Resque.delayed_queue_schedule_size,
                  'job should be enqueued')
   end
 
@@ -18,7 +18,7 @@ context 'scheduling jobs with hooks' do
     SomeRealClass.expects(:before_schedule_example).with(:foo).returns(false)
     SomeRealClass.expects(:after_schedule_example).never
     Resque.enqueue_at(enqueue_time.to_i, SomeRealClass, :foo)
-    assert_equal(0, Resque.delayed_timestamp_size(enqueue_time.to_i),
+    assert_equal(0, Resque.delayed_queue_schedule_size,
                  'job should not be enqueued')
   end
 

--- a/test/scheduler_locking_test.rb
+++ b/test/scheduler_locking_test.rb
@@ -89,7 +89,7 @@ context 'Resque::Scheduler::Locking' do
   end
 
   test 'should use the basic lock mechanism for <= Redis 2.4' do
-    Resque.redis.stubs(:info).returns('redis_version' => '2.4.16')
+    Resque.redis.redis.stubs(:info).returns('redis_version' => '2.4.16')
 
     assert_equal @subject.master_lock.class, Resque::Scheduler::Lock::Basic
   end


### PR DESCRIPTION
This should probably be merged _after_ #12.

The timestamp mechanism of resque scheduler is _beyond_ useless for shopify. The way it works is by creating a queue for every set of job params and storing the list of timestamps at which those params will run. However, in shopify every job has a unique uuid in it's job params. That means every instance of a job gets it's own timetstamp queue! Additionally, this is only used in the web server! 

I think the scheduler becomes a lot simpler to understand without this timestamps code.
