### PR TITLE
migrator

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,13 +9,30 @@ task default: [:test] if RUBY_PLATFORM =~ /java/
 
 RuboCop::RakeTask.new
 
-Rake::TestTask.new do |t|
+Rake::TestTask.new(:testing) do |t|
   t.libs << 'test'
   t.pattern = ENV['PATTERN'] || 'test/*_test.rb'
   t.options = ''.tap do |o|
     o << "--seed #{ENV['SEED']} " if ENV['SEED']
     o << '--verbose ' if ENV['VERBOSE']
   end
+end
+
+task :test do
+  puts
+  puts
+  puts "Running tests without migrator patch"
+
+  ENV['TEST_WITH_MIGRATOR'] = nil
+  Rake::Task[:testing].invoke
+
+  puts
+  puts
+  puts "Running tests with migrator patch"
+
+  ENV['TEST_WITH_MIGRATOR'] = "1"
+  Rake::Task[:testing].reenable
+  Rake::Task[:testing].invoke
 end
 
 YARD::Rake::YardocTask.new

--- a/lib/resque/scheduler_migrator.rb
+++ b/lib/resque/scheduler_migrator.rb
@@ -1,0 +1,51 @@
+require_relative 'scheduler/delaying_extensions_old'
+
+module Resque
+  module SchedulerMigrator
+    extend self
+    def old_resque
+      @@old ||= begin
+        klass = Resque.dup
+        klass.singleton_class.include(Resque::Scheduler::DelayingExtensionsOld)
+        klass
+      end
+    end
+
+    def migrate
+      timestamp = old_resque.send(:search_first_delayed_timestamp_in_range, nil, nil)
+
+      if timestamp
+        Resque::Scheduler.procline 'Migrating Delayed Items (Old Format)'
+        until timestamp.nil?
+          enqueue_delayed_items_for_timestamp(timestamp)
+          timestamp = old_resque.send(:search_first_delayed_timestamp_in_range, nil, nil)
+        end
+      end
+    end
+
+    def enqueue_next_item(timestamp)
+      item = old_resque.next_item_for_timestamp(timestamp)
+
+      if item
+        Resque::Scheduler.log "migrating #{item['class']} [delayed] from old format to new format"
+        Resque.delayed_push(timestamp, item)
+      end
+
+      item
+    end
+
+    # Enqueues all delayed jobs for a timestamp
+    def enqueue_delayed_items_for_timestamp(timestamp)
+      item = nil
+      loop do
+        Resque::Scheduler.handle_shutdown do
+          # Continually check that it is still the master
+          item = enqueue_next_item(timestamp)
+        end
+        # continue processing until there are no more ready items in this
+        # timestamp
+        break if item.nil?
+      end
+    end
+  end
+end

--- a/lib/resque/scheduler_patch.rb
+++ b/lib/resque/scheduler_patch.rb
@@ -1,0 +1,47 @@
+require_relative 'scheduler/delaying_extensions_old'
+
+module Resque
+  module SchedulerPatch
+    def old_resque
+      @@old ||= begin
+        klass = Resque.dup
+        klass.singleton_class.include(Resque::Scheduler::DelayingExtensionsOld)
+        klass
+      end
+    end
+
+    def handle_delayed_items(at_time = nil)
+      timestamp = old_resque.next_delayed_timestamp(at_time)
+      if timestamp
+        procline 'Processing Delayed Items (Old Format)'
+        until timestamp.nil?
+          enqueue_delayed_items_for_timestamp(timestamp)
+          timestamp = old_resque.next_delayed_timestamp(at_time)
+        end
+      end
+
+      super
+    end
+
+    def enqueue_next_item(timestamp)
+      item = old_resque.next_item_for_timestamp(timestamp)
+
+      if item
+        log "queuing #{item['class']} [delayed]"
+        enqueue(item)
+      end
+
+      item
+    end
+
+    def enqueue_delayed_items_for_timestamp(timestamp)
+      item = nil
+      loop do
+        handle_shutdown do
+          item = enqueue_next_item(timestamp) if master?
+        end
+        break if item.nil?
+      end
+    end
+  end
+end

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'mocha'
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'rack-test'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'simplecov'

--- a/test/scheduler_migrator_test.rb
+++ b/test/scheduler_migrator_test.rb
@@ -1,0 +1,101 @@
+# vim:fileencoding=utf-8
+require_relative 'test_helper'
+require 'resque/scheduler_migrator'
+require 'resque/scheduler_patch'
+
+context 'Resque::SchedulerMigrator' do
+  setup do
+    Resque::Scheduler.clear_schedule!
+    Resque::Scheduler.configure do |c|
+      c.dynamic = false
+      c.quiet = true
+      c.poll_sleep_amount = nil
+    end
+
+    @patched_scheduler = Resque::Scheduler.dup
+    @patched_scheduler.singleton_class.prepend(Resque::SchedulerPatch)
+    Job.run_queue = []
+  end
+
+  teardown do
+    Resque.redis.redis.flushall
+  end
+
+  class Job
+    @queue = :ivar
+
+    def self.run_queue=(o)
+      @run_queue = o
+    end
+
+    def self.run_queue
+      @run_queue
+    end
+
+    def self.perform(id)
+      self.run_queue << id
+    end
+  end
+
+  test 'migrates old format to new one' do
+    t = Time.now + 60 # in the future
+    Resque::SchedulerMigrator.old_resque.enqueue_at(t, Job, 1)
+    Resque::SchedulerMigrator.old_resque.enqueue_at(t, Job, 2)
+
+    assert_equal 1, Resque.redis.zcard('delayed_queue_schedule')
+    assert_equal 2, Resque.redis.llen("delayed:#{t.to_i}")
+
+    assert_equal 0, Resque.delayed_queue_schedule_size
+
+    Resque::SchedulerMigrator.migrate
+
+    assert_equal 2, Resque.delayed_queue_schedule_size
+
+    assert_equal 0, Resque.redis.zcard('delayed_queue_schedule')
+    assert_equal 0, Resque.redis.llen("delayed:#{t.to_i}")
+
+    Resque::Scheduler.handle_delayed_items(t)
+
+    drain_resque(:ivar)
+
+    assert_equal 0, Resque.delayed_queue_schedule_size
+    assert_equal [1, 2], Job.run_queue
+  end
+
+  test 'migrates hybrid schedules to new format' do
+    t = Time.now + 60 # in the future
+
+    Resque::SchedulerMigrator.old_resque.enqueue_at(t - 10, Job, 1)
+    Resque::SchedulerMigrator.old_resque.enqueue_at(t - 10, Job, 2)
+
+    Resque.enqueue_at(t, Job, 3)
+    Resque.enqueue_at(t, Job, 4)
+
+    Resque::SchedulerMigrator.old_resque.enqueue_at(t + 10, Job, 5)
+    Resque::SchedulerMigrator.old_resque.enqueue_at(t + 10, Job, 6)
+
+    assert_equal 2, Resque.redis.zcard('delayed_queue_schedule')
+
+    assert_equal 2, Resque.delayed_queue_schedule_size
+
+    Resque::SchedulerMigrator.migrate
+
+    assert_equal 6, Resque.delayed_queue_schedule_size
+
+    @patched_scheduler.handle_delayed_items(t + 10)
+    drain_resque(:ivar)
+
+    assert_equal [1, 2, 3, 4, 5, 6], Job.run_queue
+  end
+
+  private
+
+  def drain_resque(queue)
+    job = Resque.reserve(queue)
+
+    while job
+      job.perform
+      job = Resque.reserve(queue)
+    end
+  end
+end

--- a/test/scheduler_patch_test.rb
+++ b/test/scheduler_patch_test.rb
@@ -1,0 +1,100 @@
+# vim:fileencoding=utf-8
+require_relative 'test_helper'
+require 'resque/scheduler_patch'
+
+context 'Resque::SchedulerPatch' do
+  setup do
+    Resque::Scheduler.clear_schedule!
+    Resque::Scheduler.configure do |c|
+      c.dynamic = false
+      c.quiet = true
+      c.poll_sleep_amount = nil
+    end
+
+    @scheduler = Resque::Scheduler.dup
+    @scheduler.singleton_class.prepend(Resque::SchedulerPatch)
+    Job.run_queue = []
+  end
+
+  teardown do
+    Resque.redis.redis.flushall
+  end
+
+  class Job
+    @queue = :ivar
+
+    def self.run_queue=(o)
+      @run_queue = o
+    end
+
+    def self.run_queue
+      @run_queue
+    end
+
+    def self.perform(id)
+      self.run_queue << id
+    end
+  end
+
+  test 'can enqueue into new queue format' do
+    t = Time.now + 60 # in the future
+    Resque.enqueue_at(t, Job, 1)
+    Resque.enqueue_at(t, Job, 2)
+
+    assert_equal 0, @scheduler.old_resque.delayed_queue_schedule_size
+    assert_equal 0, @scheduler.old_resque.delayed_timestamp_size(t)
+
+    # the jobs are in the new queue format
+    assert_equal 2, Resque.delayed_queue_schedule_size
+
+    @scheduler.handle_delayed_items(t)
+
+    assert_equal 0, Resque.delayed_queue_schedule_size
+
+    drain_resque(:ivar)
+    assert_equal [1,2], Job.run_queue
+  end
+
+  test 'reads from old format before new one' do
+    t = Time.now + 60 # in the future
+    @scheduler.old_resque.enqueue_at(t, Job, 1)
+    @scheduler.old_resque.enqueue_at(t, Job, 2)
+
+    expected_queue = [
+      {"args"=>[1], "class"=>"Job", "queue"=>"ivar"},
+      {"args"=>[2], "class"=>"Job", "queue"=>"ivar"}
+    ]
+
+    # we only have one entry in the timestamps queue
+    assert_equal 1, @scheduler.old_resque.delayed_queue_schedule_size
+    assert_equal 2, @scheduler.old_resque.delayed_timestamp_size(t)
+    assert_equal expected_queue, @scheduler.old_resque.delayed_timestamp_peek(t, 0, 2)
+
+    Resque.enqueue_at(t, Job, 3)
+    Resque.enqueue_at(t, Job, 4)
+
+    # only pushes to the new style
+    assert_equal 1, Resque.redis.zcard(:delayed_queue_schedule)
+    assert_equal 2, Resque.delayed_queue_schedule_size
+
+    # Check that next job is from old first
+    @scheduler.handle_delayed_items(t)
+
+    assert_equal 0, Resque.delayed_queue_schedule_size
+    assert_equal 0, Resque.redis.zcard(:delayed_queue_schedule)
+
+    drain_resque(:ivar)
+    assert_equal [1,2,3,4], Job.run_queue
+  end
+
+  private
+
+  def drain_resque(queue)
+    job = Resque.reserve(queue)
+
+    while job
+      job.perform
+      job = Resque.reserve(queue)
+    end
+  end
+end

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -15,6 +15,14 @@ context 'Resque::Scheduler' do
     Resque::Scheduler.send(:instance_variable_set, :@shutdown, false)
   end
 
+  test 'testing with TEST_WITH_MIGRATOR is actually doing something' do
+    if ENV['TEST_WITH_MIGRATOR']
+      assert Resque::Scheduler.old_resque
+    else
+      assert !Resque::Scheduler.methods.include?(:old_resque)
+    end
+  end
+
   test 'enqueue constantizes' do
     Resque::Scheduler.env = 'production'
     config = {

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,11 @@ $LOAD_PATH.unshift File.dirname(File.expand_path(__FILE__)) + '/../lib'
 require 'resque-scheduler'
 require 'resque/scheduler/server'
 
+if ENV['TEST_WITH_MIGRATOR']
+  require 'resque/scheduler_patch'
+  Resque::Scheduler.singleton_class.prepend(Resque::SchedulerPatch)
+end
+
 ##
 # test/spec/mini 3
 # original work: http://gist.github.com/25455


### PR DESCRIPTION
This PR contains the code to migrate to the new resque scheduler format.

The migrator is a patch that is attached to `Resque::Scheduler`. It will force the scheduler to check the **old** format before the **new** format. Once enabled we should only need to let it run for approximately 12 days before all jobs will have been migrated to the new format. 

Additionally, we maintain a copy of the `delaying_extensions` from before the changes to the ZSET format were made. That is how the migrator is able to interact with the old format of jobs.