### PR TITLE
Add a revert migrator to resque scheduler

### DIFF
--- a/lib/resque/scheduler/version.rb
+++ b/lib/resque/scheduler/version.rb
@@ -2,6 +2,6 @@
 
 module Resque
   module Scheduler
-    VERSION = '4.3.0'.freeze
+    VERSION = '5.0.0'.freeze
   end
 end

--- a/lib/resque/scheduler_revert_migrator.rb
+++ b/lib/resque/scheduler_revert_migrator.rb
@@ -1,0 +1,53 @@
+require_relative 'scheduler/delaying_extensions_old'
+
+# This module provides functionality to abort a migration to the new scheduler format
+# it will copy jobs from the new format to the old one
+
+module Resque
+  module SchedulerRevertMigrator
+    extend self
+
+    def old_resque
+      @@old ||= begin
+        klass = Resque.dup
+        klass.singleton_class.include(Resque::Scheduler::DelayingExtensionsOld)
+        klass
+      end
+    end
+
+    def revert_migrate
+      Resque::Scheduler.procline 'Reverting Delayed Items to Old Format'
+      item = nil
+
+      # The new scheduler performs a peek to read the job before processing it.
+      # Therefore, we must interrupt it's processing first
+      Resque.redis.rename :delayed_queue, :delayed_queue_recovery
+
+      loop do
+        Resque::Scheduler.handle_shutdown do
+          item, timestamp = next_delayed_item
+
+          if item
+            Resque::Scheduler.log "queuing #{item['class']} [delayed]"
+            old_resque.delayed_push(timestamp, item)
+          end
+        end
+
+        break if item.nil?
+      end
+    end
+
+    def next_delayed_item
+      item, time = Resque.redis.zrangebyscore(:delayed_queue_recovery, 0.0, '+inf', limit: [0, 1], with_scores: true).first
+
+      if item
+        decoded = Resque.send(:decode_without_nonce, item)
+
+        Resque.redis.zrem(:delayed_queue_recovery, item)
+        Resque.redis.srem("timestamps:#{Resque.encode(decoded)}", "delayed:#{time.to_i}")
+
+        [decoded, time]
+      end
+    end
+  end
+end

--- a/test/scheduler_revert_migrator_test.rb
+++ b/test/scheduler_revert_migrator_test.rb
@@ -1,0 +1,99 @@
+# vim:fileencoding=utf-8
+require_relative 'test_helper'
+require 'resque/scheduler_revert_migrator'
+require 'resque/scheduler_patch'
+
+context 'Resque::SchedulerRevertMigrator' do
+  setup do
+    Resque::Scheduler.clear_schedule!
+    Resque::Scheduler.configure do |c|
+      c.dynamic = false
+      c.quiet = true
+      c.poll_sleep_amount = nil
+    end
+
+    @patched_scheduler = Resque::Scheduler.dup
+    @patched_scheduler.singleton_class.prepend(Resque::SchedulerPatch)
+    Job.run_queue = []
+  end
+
+  teardown do
+    Resque.redis.redis.flushall
+  end
+
+  class Job
+    @queue = :ivar
+
+    def self.run_queue=(o)
+      @run_queue = o
+    end
+
+    def self.run_queue
+      @run_queue
+    end
+
+    def self.perform(id)
+      self.run_queue << id
+    end
+  end
+
+  test 'migrates new format to old one' do
+    t = Time.now + 60 # in the future
+    Resque.enqueue_at(t, Job, 1)
+    Resque.enqueue_at(t, Job, 2)
+
+    assert_equal 2, Resque.delayed_queue_schedule_size
+    assert_equal 0, Resque.redis.zcard('delayed_queue_schedule')
+    assert_equal 0, Resque.redis.llen("delayed:#{t.to_i}")
+
+    Resque::SchedulerRevertMigrator.revert_migrate
+
+    assert_equal 1, Resque.redis.zcard('delayed_queue_schedule')
+    assert_equal 2, Resque.redis.llen("delayed:#{t.to_i}")
+
+    @patched_scheduler.handle_delayed_items(t)
+
+    drain_resque(:ivar)
+
+    assert_equal 0, Resque.delayed_queue_schedule_size
+    assert_equal [1, 2], Job.run_queue
+  end
+
+  test 'migrates hybrid schedules to new format' do
+    t = Time.now + 60 # in the future
+
+    Resque::SchedulerRevertMigrator.old_resque.enqueue_at(t - 10, Job, 1)
+    Resque::SchedulerRevertMigrator.old_resque.enqueue_at(t - 10, Job, 2)
+
+    Resque.enqueue_at(t, Job, 3)
+    Resque.enqueue_at(t, Job, 4)
+
+    Resque::SchedulerRevertMigrator.old_resque.enqueue_at(t + 10, Job, 5)
+    Resque::SchedulerRevertMigrator.old_resque.enqueue_at(t + 10, Job, 6)
+
+    assert_equal 2, Resque.redis.zcard('delayed_queue_schedule')
+
+    assert_equal 2, Resque.delayed_queue_schedule_size
+
+    Resque::SchedulerRevertMigrator.revert_migrate
+
+    assert_equal 3, Resque.redis.zcard('delayed_queue_schedule')
+    assert_equal 0, Resque.delayed_queue_schedule_size
+
+    @patched_scheduler.handle_delayed_items(t + 10)
+    drain_resque(:ivar)
+
+    assert_equal [1, 2, 3, 4, 5, 6], Job.run_queue
+  end
+
+  private
+
+  def drain_resque(queue)
+    job = Resque.reserve(queue)
+
+    while job
+      job.perform
+      job = Resque.reserve(queue)
+    end
+  end
+end


### PR DESCRIPTION
This adds a migration that reverts the new scheduler code. It is meant to be used if we decide to abort the migration for whatever reason. I've provided a test suite for it as well.

Additionally, this bumps the gem version to `5.0.0` I felt that was appropriate since we are radically changing the backend to the gem. We also need that to do version checks in shopify core.