### PR TITLE
Performance: dequeue jobs in batches

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,8 +4,7 @@ require 'rake/testtask'
 require 'rubocop/rake_task'
 require 'yard'
 
-task default: [:rubocop, :test] unless RUBY_PLATFORM =~ /java/
-task default: [:test] if RUBY_PLATFORM =~ /java/
+task default: [:testing]
 
 RuboCop::RakeTask.new
 

--- a/lib/resque/scheduler/configuration.rb
+++ b/lib/resque/scheduler/configuration.rb
@@ -68,6 +68,13 @@ module Resque
         @poll_sleep_amount ||=
           Float(ENV.fetch('RESQUE_SCHEDULER_INTERVAL', '5'))
       end
+
+      attr_writer :dequeue_batch_size
+
+      def dequeue_batch_size
+        @dequeue_batch_size ||=
+          Integer(ENV.fetch('RESQUE_SCHEDULER_DEQUEUE_BATCH_SIZE', '10'))
+      end
     end
   end
 end

--- a/test/benchmarks/scheduler.rb
+++ b/test/benchmarks/scheduler.rb
@@ -2,17 +2,30 @@
 
 require_relative '../test_helper'
 require 'benchmark'
-require 'stackprof'
 
 context 'Resque::Scheduler' do
   setup do
     Resque.redis.redis.flushall
   end
 
-  test 'testing with TEST_WITH_MIGRATOR is actually doing something' do
-    5_000.times { Resque.enqueue_in_with_queue(:default, 0, SomeJob) }
-    StackProf.run(mode: :cpu, raw: true, out: 'stackprof.dump') do
-      puts Benchmark.measure { Resque::Scheduler.handle_delayed_items }
+  test "benchmark dequeuing" do
+    [1, 10].each do |batch_size|
+      10_000.times { Resque.enqueue_in_with_queue(:default, 0, SomeJob) }
+
+      with_dequeue_batch_size(batch_size) do
+        puts "benchmarking dequeuing in batches of #{batch_size}"
+        puts Benchmark.measure { Resque::Scheduler.handle_delayed_items }
+      end
     end
+  end
+
+  private
+
+  def with_dequeue_batch_size(batch_size)
+    old = Resque::Scheduler.dequeue_batch_size
+    Resque::Scheduler.dequeue_batch_size = batch_size
+    yield
+  ensure
+    Resque::Scheduler.dequeue_batch_size = old
   end
 end

--- a/test/benchmarks/scheduler.rb
+++ b/test/benchmarks/scheduler.rb
@@ -10,7 +10,7 @@ context 'Resque::Scheduler' do
   end
 
   test 'testing with TEST_WITH_MIGRATOR is actually doing something' do
-    10_000.times { Resque.enqueue_in_with_queue(:default, 0, SomeJob) }
+    5_000.times { Resque.enqueue_in_with_queue(:default, 0, SomeJob) }
     StackProf.run(mode: :cpu, raw: true, out: 'stackprof.dump') do
       puts Benchmark.measure { Resque::Scheduler.handle_delayed_items }
     end

--- a/test/benchmarks/scheduler.rb
+++ b/test/benchmarks/scheduler.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'benchmark'
+require 'stackprof'
+
+context 'Resque::Scheduler' do
+  setup do
+    Resque.redis.redis.flushall
+  end
+
+  test 'testing with TEST_WITH_MIGRATOR is actually doing something' do
+    10_000.times { Resque.enqueue_in_with_queue(:default, 0, SomeJob) }
+    StackProf.run(mode: :cpu, raw: true, out: 'stackprof.dump') do
+      puts Benchmark.measure { Resque::Scheduler.handle_delayed_items }
+    end
+  end
+end


### PR DESCRIPTION
Yesterday, during an incident that affected cloud pods, we observed resque-scheduler causing job scheduling SLO violation.

![image](https://user-images.githubusercontent.com/6955854/36190688-98829b7c-1127-11e8-8944-e14bc45823f8.png)

We tracked down the violation to the high volume of webhook jobs that were being scheduled for the future (put into the resque-scheduler queue as opposed to resque). Shedding this load solved the unbounded queue growth.

This PR is a first attempt at addressing this performance problem by batching the operation of dequeuing jobs. The most important caveat of this solution is that the number of jobs that _can_ be dropped by a hard crash is increased from a single job to `dequeue_batch_size` jobs. Furthermore, since jobs are dequeued in batches, a failure in Redis that lasts through the period of enqueueing a batch of jobs is likely to affect the whole batch.

I profiled the dequeueing + enqueueing process and found that we spend an equal amount of time  dequeuing as we do enqueueing with a batch size of 1:
![batch-1](https://user-images.githubusercontent.com/6955854/36190968-02b6a8b6-1129-11e8-9eeb-7ad8eb11f4b9.png)

I then profiled the code with a batch size of 10:
![batch10](https://user-images.githubusercontent.com/6955854/36190941-dce745d2-1128-11e8-9bd2-543fd09d64fc.png)

As you can see, we are still spending a considerable amount of time _enqueueing_ jobs into Redis. The enqueue codepath is more complicated to batch up and possibly not worth the effort for now.

Below is benchmark results (benchmark code in the diff) that show the impact of dequeue batching (n.b. this is a local Redis instance. Results in production may vary). I picked a compromise between speedup and damage from failures and used a batch size of 10 by default (tuneable in an env variable):
![image](https://user-images.githubusercontent.com/6955854/36191319-817cffb4-112a-11e8-81c3-55b12356ef45.png)

As mentioned, the results in the production environment may vary due to different latency conditions.

@Shopify/core-cloud-swat @Shopify/redis-memcached