### PR TITLE
Cache Redis version instead of checking it over and over again

### DIFF
--- a/lib/resque/scheduler/locking.rb
+++ b/lib/resque/scheduler/locking.rb
@@ -97,7 +97,7 @@ module Resque
       end
 
       def redis_master_version
-        Resque.redis.redis.info['redis_version'].to_f
+        @redis_master_version ||= Resque.redis.redis.info['redis_version'].to_f
       end
     end
   end


### PR DESCRIPTION
Looks like every iteration of the `handle_delayed_items` loop calls `master?` which calls `supports_lua?` which triggers an `INFO` command. Besides the waste of network roundtrips, those info commands are also sometimes not cheap (not sure if this code is the reason, but across the board, `INFO` is our 6th most time consuming query, according to vividcortex).