### PR TITLE
Remove unnecessary reimplementation of SET NX

### DIFF
--- a/test/scheduler_locking_test.rb
+++ b/test/scheduler_locking_test.rb
@@ -310,18 +310,5 @@ context 'Resque::Scheduler::Lock::Resilient' do
       @lock.timeout = 100
       assert_not_nil @lock.instance_variable_get(:@locked_sha)
     end
-
-    test 'setting lock timeout nils out acquire script' do
-      @lock.acquire!
-      @lock.timeout = 100
-      assert_equal nil, @lock.instance_variable_get(:@acquire_sha)
-    end
-
-    test 'setting lock timeout does not nil out acquire script if not held' do
-      @lock.acquire!
-      @lock.stubs(:locked?).returns(false)
-      @lock.timeout = 100
-      assert_not_nil @lock.instance_variable_get(:@acquire_sha)
-    end
   end
 end


### PR DESCRIPTION
The version of Redis we use supports `SET` with the `NX` and `EX` options. Probably not a big win but it kinda bugged me. This will save at least one Lua call for every invocation of `master?` (which happens pretty frequently).