### PR TITLE
Allow backup instances to enqueue jobs

### DIFF
--- a/lib/resque/scheduler/lock/base.rb
+++ b/lib/resque/scheduler/lock/base.rb
@@ -20,7 +20,7 @@ module Resque
         end
 
         def value
-          @value ||= [hostname, process_id].join(':')
+          [hostname, process_id].join(':')
         end
 
         # Returns true if you currently hold the lock.
@@ -47,9 +47,11 @@ module Resque
 
         def hostname
           local_hostname = Socket.gethostname
-          Socket.gethostbyname(local_hostname).first
-        rescue
-          local_hostname
+          @hostname ||= begin
+            Socket.gethostbyname(local_hostname).first
+          rescue
+            local_hostname
+          end
         end
 
         def process_id

--- a/lib/resque/scheduler/lock/basic.rb
+++ b/lib/resque/scheduler/lock/basic.rb
@@ -6,10 +6,7 @@ module Resque
     module Lock
       class Basic < Base
         def acquire!
-          if Resque.redis.setnx(key, value)
-            extend_lock!
-            true
-          end
+          Resque.redis.set(key, value, ex: timeout, nx: true)
         end
 
         def locked?

--- a/test/multi_process_test.rb
+++ b/test/multi_process_test.rb
@@ -2,6 +2,8 @@
 require_relative 'test_helper'
 
 context 'Multi Process' do
+  include ForkingTestHelper
+
   test 'setting schedule= from many process does not corrupt the schedules' do
     # more info on why we're not using threads:
     # https://github.com/resque/resque-scheduler/pull/439#discussion_r16788812
@@ -80,50 +82,5 @@ context 'Multi Process' do
     counts.each_with_index do |c, i|
       assert_equal schedule_count, c, "schedule count is incorrect (c: #{i})"
     end
-  end
-
-  private
-
-  def fork_with_marshalled_pipe_and_result
-    pipe_read, pipe_write = IO.pipe
-    pid = fork do
-      pipe_read.close
-      result = begin
-        [yield, nil]
-      rescue StandardError => exc
-        [nil, exc]
-      end
-      pipe_write.syswrite(Marshal.dump(result))
-      # exit true the process to get around fork issues on minitest 5
-      # see https://github.com/seattlerb/minitest/issues/467
-      Process.exit!(true)
-    end
-    pipe_write.close
-
-    [pid, pipe_read]
-  end
-
-  def get_results_from_children(children)
-    results = []
-    children.each do |pid, pipe|
-      wait_for_child_process_to_terminate(pid)
-
-      raise "forked process failed with #{$CHILD_STATUS}" unless $CHILD_STATUS.success?
-      result, exc = Marshal.load(pipe.read)
-      raise exc if exc
-      results << result
-    end
-    results
-  end
-
-  def wait_for_child_process_to_terminate(pid = -1, timeout = 30)
-    Timeout.timeout(timeout) do
-      Process.wait(pid)
-    end
-  rescue Timeout::Error
-    Process.kill('KILL', pid)
-    # collect status so it doesn't stick around as zombie process
-    Process.wait(pid)
-    flunk 'Child process did not terminate in time.'
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,8 @@ $LOAD_PATH.unshift File.dirname(File.expand_path(__FILE__)) + '/../lib'
 require 'resque-scheduler'
 require 'resque/scheduler/server'
 
+Dir[(File.expand_path(__dir__)) + '/test_helpers/*.rb'].each { |f| require f }
+
 ##
 # test/spec/mini 3
 # original work: http://gist.github.com/25455

--- a/test/test_helpers/forking_test_helper.rb
+++ b/test/test_helpers/forking_test_helper.rb
@@ -1,0 +1,46 @@
+module ForkingTestHelper
+  def fork_with_marshalled_pipe_and_result
+    pipe_read, pipe_write = IO.pipe
+    pid = fork do
+      pipe_read.close
+      result = begin
+        [yield, nil]
+      rescue StandardError => exc
+        [nil, exc]
+      end
+
+      pipe_write.syswrite(Marshal.dump(result))
+      # exit true the process to get around fork issues on minitest 5
+      # see https://github.com/seattlerb/minitest/issues/467
+      Process.exit!(true)
+    end
+    pipe_write.close
+
+    [pid, pipe_read]
+  end
+
+  def get_results_from_children(children)
+    results = []
+    children.each do |pid, pipe|
+      wait_for_child_process_to_terminate(pid)
+
+      raise "forked process failed with #{$CHILD_STATUS}" unless $CHILD_STATUS.success?
+      result, exc = Marshal.load(pipe.read)
+      raise exc if exc
+      results << result
+    end
+    results
+  end
+
+  def wait_for_child_process_to_terminate(pid = -1, timeout = 30)
+    Timeout.timeout(timeout) do
+      Process.wait(pid)
+    end
+  rescue Timeout::Error
+    Process.kill('KILL', pid)
+    # collect status so it doesn't stick around as zombie process
+    Process.wait(pid)
+    flunk 'Child process did not terminate in time.'
+  end
+
+end


### PR DESCRIPTION
This is the idea that Xavier mentioned in #23

Currently, we run multiple backup resque scheduler processes in each datacenter and they do nothing but check if they can become master. 

This PR allows those processes to actually pop and enqueue _delayed_ jobs. The master instance is still the only instance that can enqueue _scheduled_ jobs:

https://github.com/Shopify/resque-scheduler/blob/b6b64c5fdd4be27b6a5fd15a360279099b02e8c7/lib/resque/scheduler.rb#L411-L417

This is something that can now be done safely thanks to the work done in #23:

https://github.com/Shopify/resque-scheduler/blob/b6b64c5fdd4be27b6a5fd15a360279099b02e8c7/lib/resque/scheduler/delaying_extensions.rb#L72

Something like this PR would allow us to never worry about resque scheduler being CPU bound again, something that we observed multiple times particularly in cloud pods.

@Shopify/pods 