### PR TITLE
Make check and releasing master lock atomic

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -65,7 +65,7 @@ module Resque
               end
             rescue Errno::EAGAIN, Errno::ECONNRESET, Redis::CannotConnectError => e
               log! e.message
-              release_master_lock
+              release_master_lock_if_master
             end
             poll_sleep
           end
@@ -361,7 +361,7 @@ module Resque
 
       def before_shutdown
         stop_rufus_scheduler
-        release_master_lock
+        release_master_lock_if_master
       end
 
       # Sets the shutdown flag, clean schedules and exits if sleeping

--- a/lib/resque/scheduler/lock/base.rb
+++ b/lib/resque/scheduler/lock/base.rb
@@ -28,17 +28,17 @@ module Resque
           raise NotImplementedError
         end
 
-        # Releases the lock.
-        def release!
-          Resque.redis.del(key) == 1
-        end
-
         # Releases the lock iff we own it
-        def release
-          locked? && release!
+        def release_if_locked
+          raise NotImplementedError
         end
 
         private
+
+        # Releases the lock unconditionally
+        def release!
+          Resque.redis.del(key) == 1
+        end
 
         # Extends the lock by `timeout` seconds.
         def extend_lock!

--- a/lib/resque/scheduler/lock/basic.rb
+++ b/lib/resque/scheduler/lock/basic.rb
@@ -21,6 +21,11 @@ module Resque
 
           false
         end
+
+
+        def release_if_locked
+          locked? && release!
+        end
       end
     end
   end

--- a/lib/resque/scheduler/lock/resilient.rb
+++ b/lib/resque/scheduler/lock/resilient.rb
@@ -13,6 +13,10 @@ module Resque
           Resque::Scheduler::Lua.locked(key, value, @timeout).to_i == 1
         end
 
+        def release_if_locked
+          Resque::Scheduler::Lua.deleq(key, value).to_i == 1
+        end
+
         def timeout=(seconds)
           if locked?
             @timeout = seconds

--- a/lib/resque/scheduler/locking.rb
+++ b/lib/resque/scheduler/locking.rb
@@ -66,16 +66,8 @@ module Resque
         master_lock.acquire! || master_lock.locked?
       end
 
-      def release_master_lock!
-        warn "#{self}\#release_master_lock! is deprecated because it does " \
-             "not respect lock ownership. Use #{self}\#release_master_lock " \
-             "instead (at #{caller.first}"
-
-        master_lock.release!
-      end
-
-      def release_master_lock
-        master_lock.release
+      def release_master_lock_if_master
+        master_lock.release_if_locked
       rescue Errno::EAGAIN, Errno::ECONNRESET, Redis::CannotConnectError
         @master_lock = nil
       end

--- a/lib/resque/scheduler/lua.rb
+++ b/lib/resque/scheduler/lua.rb
@@ -9,6 +9,10 @@ module Resque
         evalsha(:zpop, [key], [min, max, offset, count])
       end
 
+      def deleq(key, expected_value)
+        evalsha(:deleq, [key], [expected_value])
+      end
+
       def locked(lock_key, token, timeout)
         evalsha(:locked, [lock_key], [token, timeout])
       end

--- a/lib/resque/scheduler/lua/deleq.lua
+++ b/lib/resque/scheduler/lua/deleq.lua
@@ -1,0 +1,4 @@
+if redis.call('get', KEYS[1]) == ARGV[1] then
+  return redis.call('del', KEYS[1])
+end
+return 0

--- a/test/scheduler_locking_test.rb
+++ b/test/scheduler_locking_test.rb
@@ -112,15 +112,9 @@ context 'Resque::Scheduler::Locking' do
     assert !@subject.master?, 'should not be master'
   end
 
-  test 'release_master_lock should delegate to master_lock' do
-    @subject.master_lock.expects(:release)
-    @subject.release_master_lock
-  end
-
-  test 'release_master_lock! should delegate to master_lock' do
-    @subject.expects(:warn)
-    @subject.master_lock.expects(:release!)
-    @subject.release_master_lock!
+  test 'release_master_lock_if_master should delegate to master_lock' do
+    @subject.master_lock.expects(:release_if_locked)
+    @subject.release_master_lock_if_master
   end
 end
 
@@ -150,7 +144,7 @@ context 'Resque::Scheduler::Lock::Basic' do
   end
 
   teardown do
-    @lock.release!
+    @lock.send(:release!)
   end
 
   test 'you should not have the lock if someone else holds it' do
@@ -176,7 +170,7 @@ context 'Resque::Scheduler::Lock::Basic' do
     assert @lock.acquire!, 'should have acquired the master lock'
     assert @lock.locked?, 'should be locked'
 
-    @lock.release!
+    @lock.release_if_locked
 
     assert !@lock.locked?, 'should not be locked'
   end
@@ -213,7 +207,7 @@ context 'Resque::Scheduler::Lock::Resilient' do
     end
 
     teardown do
-      @lock.release!
+      @lock.send(:release!)
     end
 
     test 'you should not have the lock if someone else holds it' do
@@ -250,7 +244,7 @@ context 'Resque::Scheduler::Lock::Resilient' do
       assert @lock.acquire!, 'should have acquired the master lock'
       assert @lock.locked?, 'should be locked'
 
-      @lock.release!
+      @lock.release_if_locked
 
       assert !@lock.locked?, 'should not be locked'
     end

--- a/test/scheduler_task_test.rb
+++ b/test/scheduler_task_test.rb
@@ -22,7 +22,7 @@ context 'Resque::Scheduler' do
   end
 
   test 'sending TERM to scheduler breaks out of poll_sleep' do
-    Resque::Scheduler.expects(:release_master_lock)
+    Resque::Scheduler.expects(:release_master_lock_if_master)
 
     @pid = Process.pid
     Thread.new do
@@ -34,8 +34,8 @@ context 'Resque::Scheduler' do
       Resque::Scheduler.run
     end
 
-    Resque::Scheduler.unstub(:release_master_lock)
-    Resque::Scheduler.release_master_lock
+    Resque::Scheduler.unstub(:release_master_lock_if_master)
+    Resque::Scheduler.release_master_lock_if_master
   end
 
   test 'can start successfully' do
@@ -54,7 +54,7 @@ context 'Resque::Scheduler' do
 
   test 'sending TERM to scheduler breaks out when poll_sleep_amount = 0' do
     Resque::Scheduler.poll_sleep_amount = 0
-    Resque::Scheduler.expects(:release_master_lock)
+    Resque::Scheduler.expects(:release_master_lock_if_master)
 
     @pid = Process.pid
     Thread.new do
@@ -66,7 +66,7 @@ context 'Resque::Scheduler' do
       Resque::Scheduler.run
     end
 
-    Resque::Scheduler.unstub(:release_master_lock)
-    Resque::Scheduler.release_master_lock
+    Resque::Scheduler.unstub(:release_master_lock_if_master)
+    Resque::Scheduler.release_master_lock_if_master
   end
 end


### PR DESCRIPTION
The process of checking if we're master and releasing the master lock is theoretically broken since we do it in rubby land. I don't expect this is a huge deal but with the additional calls being made to the method in https://github.com/Shopify/resque-scheduler/pull/25 I would feel more comfortable making this truly atomic

@Shopify/pods 