### PR TITLE
Fix redis namespace deprecations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
 
       # Run rspec in parallel
       - run: |
-          rake testing
+          REDIS_NAMESPACE_DEPRECATIONS=1 rake testing
 
       # Save test results for timing analysis
       - store_test_results:

--- a/lib/resque/scheduler/env.rb
+++ b/lib/resque/scheduler/env.rb
@@ -43,7 +43,7 @@ module Resque
         end
 
         Process.daemon(true, !Resque::Scheduler.quiet)
-        Resque.redis.redis.client.reconnect
+        Resque.redis.redis._client.reconnect
       end
 
       def setup_pid_file

--- a/lib/resque/scheduler/env.rb
+++ b/lib/resque/scheduler/env.rb
@@ -43,7 +43,7 @@ module Resque
         end
 
         Process.daemon(true, !Resque::Scheduler.quiet)
-        Resque.redis.client.reconnect
+        Resque.redis.redis.client.reconnect
       end
 
       def setup_pid_file

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -15,10 +15,15 @@ context 'Env' do
   test 'reconnects redis when background is true' do
     Process.stubs(:daemon)
     mock_redis_client = mock('redis_client')
-    mock_redis = mock('redis')
-    mock_redis.expects(:client).returns(mock_redis_client)
     mock_redis_client.expects(:reconnect)
-    Resque.expects(:redis).returns(mock_redis)
+
+    mock_redis = mock('redis')
+    mock_redis.expects(:_client).returns(mock_redis_client)
+
+    mock_redis_namespace = mock('redis_namespace')
+    mock_redis_namespace.expects(:redis).returns(mock_redis)
+
+    Resque.expects(:redis).returns(mock_redis_namespace)
     env = new_env(background: true)
     env.setup
   end

--- a/test/scheduler_locking_test.rb
+++ b/test/scheduler_locking_test.rb
@@ -221,7 +221,7 @@ context 'Resque::Scheduler::Lock::Resilient' do
       assert @lock.acquire!
       assert @lock.locked?
 
-      Resque.redis.script(:flush)
+      Resque.redis.redis.script(:flush)
 
       assert @lock.locked?
       assert_false @lock.acquire!


### PR DESCRIPTION
We want to start using redis-namespace to start and prefix keys, but I want to make sure we don't use any of the deprecated features.

This PR addresses the deprecations and changes a little bit how the LUA scripts works. Instead of calling `redis.script(:load, body)`, I lazy load them by fallbacking on EVAL and computing the sha myself ahead of time. Essentially on misses, instead of doing `EVALSHA -> miss, SCRIPT LOAD, EVALSHA -> hit`, we do `EVALSHA -> miss, EVAL -> hit`.